### PR TITLE
Adds SpiderMonkey and JSC

### DIFF
--- a/importer/package.json
+++ b/importer/package.json
@@ -39,7 +39,7 @@
     "@octokit/plugin-throttling": "^9.0.3",
     "cli-progress": "^3.12.0",
     "json5": "^2.2.3",
-    "octokit": "^3.1.2",
+    "octokit": "^4.1.0",
     "puppeteer": "^23.5.0",
     "yaml": "^2.4.5"
   }

--- a/pages/cve/list.vue
+++ b/pages/cve/list.vue
@@ -56,7 +56,7 @@
             </b-select>
           </b-field>
 
-          <b-field label="Component" class="ml-2">
+          <b-field label="Component" class="ml-2" v-if="!filter_component">
             <b-select
               v-model="filter_component"
               placeholder="Component"
@@ -68,10 +68,18 @@
             </b-select>
           </b-field>
 
+          <b-field label="Component" class="ml-2" v-else>
+            <b-tag
+              closable
+              size="is-large"
+              @close="filter_component = null"
+              >
+              {{ filter_component }}
+            </b-tag>
+          </b-field>
+
           <b-field label="Private bugs" class="ml-2">
-            <!--<b-radio-button v-model="hide_private" native-value="true">Hide</b-radio-button>-->
-            <!--<b-radio-button v-model="hide_private" native-value="false">Show</b-radio-button>-->
-            <b-switch v-model="hide_private" @change="updateUrl">Show</b-switch>
+            <b-switch v-model="hide_private" @change="updateUrl">Hide</b-switch>
           </b-field>
         </b-field>
 

--- a/repositories.json5
+++ b/repositories.json5
@@ -208,6 +208,7 @@
     reviewers: false,
     treemap: false,
   },
+
   {
     name: "Ladybird",
     dirname: "ladybird",
@@ -217,6 +218,7 @@
     reviewers: false,
     treemap: false,
   },
+
   {
     name: "Servo",
     dirname: "servo",
@@ -225,5 +227,29 @@
     repository: "servo",
     reviewers: false,
     treemap: false,
-  }
+  },
+
+  {
+    name: "SpiderMonkey",
+    dirname: "spidermonkey",
+    color: "#e66000",
+    owner: "mozilla",
+    repository: "gecko-dev",
+    cone: "js",
+    parent: "gecko",
+    reviewers: false,
+    treemap: false,
+  },
+
+  {
+    name: "JSC",
+    dirname: "jsc",
+    color: "#1393ef",
+    owner: "WebKit",
+    repository: "WebKit",
+    cone: "Source/JavaScriptCore",
+    parent: "WebKit",
+    reviewers: false,
+    treemap: false,
+  },
 ]


### PR DESCRIPTION
Adds new top-level options for SpiderMonkey and JSC. I'm not entirely sure that the SM data is correct (doesn't seem to go back more than a couple of years), but spot-checking the derived data, they seem to be in the ballpark.

The `color` values are sus, as I just-reused existing ones. Guidance there appreciated.

On license, I'm a Chromium contributor in good standing (slightlyoff@chromium.org) and provide this code under those terms, or will disclaim any interests in it per your request.