### PR TITLE
Add accumulative view option for organization contributions

### DIFF
--- a/components/Organizations.vue
+++ b/components/Organizations.vue
@@ -72,6 +72,7 @@ const props = defineProps({
   },
   others: { type: Boolean, default: false},
   percent: { type: Boolean, default: false},
+  accumulative: { type: Boolean, default: false},
 })
 
 const repositoriesColor = new Map();
@@ -232,6 +233,31 @@ const consolidateData = async function() {
     if (!props.others) {
       for(const date in data) {
         delete data[date]["Others"];
+      }
+    }
+  }
+
+  if (props.accumulative) {
+    const sortedDates = Object.keys(data).sort();
+    const allLabels = new Set();
+
+    for (const date in data) {
+      for (const label in data[date]) {
+        allLabels.add(label);
+      }
+    }
+
+    const cumulativeValues = {};
+    for (const label of allLabels) {
+      cumulativeValues[label] = 0;
+    }
+
+    for (const date of sortedDates) {
+      for (const label of allLabels) {
+        if (data[date][label]) {
+          cumulativeValues[label] += data[date][label];
+        }
+        data[date][label] = cumulativeValues[label];
       }
     }
   }

--- a/pages/organizations/commits.vue
+++ b/pages/organizations/commits.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <Navbar/>
-    {{ display }}
     <section class="section">
       <div class="container">
         <h1 class="title">Organizations contributions</h1>

--- a/pages/organizations/commits.vue
+++ b/pages/organizations/commits.vue
@@ -129,7 +129,8 @@
           :chart="chart"
           :dates="dates"
           :others="others"
-          :percent="percent === 'percent'" >
+          :percent="percent === 'percent'"
+          :accumulative="percent === 'accumulative'" >
 
           <b-field class="has-addons">
             <b-radio-button size="small" name="metric"
@@ -156,6 +157,10 @@
             <b-radio-button size="small" name="percent"
               v-model="percent" native-value="percent" >
               Percent
+            </b-radio-button>
+            <b-radio-button size="small" name="percent"
+              v-model="percent" native-value="accumulative" >
+              Accumulative
             </b-radio-button>
           </b-field>
 
@@ -237,7 +242,7 @@ if (route.query.dates) {
 }
 
 const others = ref(route.query.others === null);
-const percent = ref(route.query.percent === null ? 'percent' : 'absolute');
+const percent = ref(route.query.percent === null ? 'percent' : route.query.percent || 'absolute');
 
 const updateUrl = () => {
   router.push({
@@ -253,7 +258,7 @@ const updateUrl = () => {
       chart: chart.value,
       dates: dates.value.map(d => d.toISOString().split("T")[0]).join(','),
       others: others.value ? null : undefined,
-      percent: percent.value === "percent" ? null : undefined,
+      percent: percent.value === "percent" ? null : percent.value === "absolute" ? undefined : percent.value,
     },
   });
 }

--- a/pages/organizations/commits.vue
+++ b/pages/organizations/commits.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <Navbar/>
+    {{ display }}
     <section class="section">
       <div class="container">
         <h1 class="title">Organizations contributions</h1>
@@ -129,8 +130,8 @@
           :chart="chart"
           :dates="dates"
           :others="others"
-          :percent="percent === 'percent'"
-          :accumulative="percent === 'accumulative'" >
+          :display="display"
+        >
 
           <b-field class="has-addons">
             <b-radio-button size="small" name="metric"
@@ -150,17 +151,19 @@
           <div class="mr-2"></div>
 
           <b-field class="has-addons">
-            <b-radio-button size="small" name="percent"
-              v-model="percent" native-value="absolute" >
+            <b-radio-button size="small" name="display"
+              v-model="display" native-value="accumulative"
+              :disabled="metric == 'contributor'"
+            >
+              Accumulative
+            </b-radio-button>
+            <b-radio-button size="small" name="display"
+              v-model="display" native-value="absolute" >
               Absolute
             </b-radio-button>
-            <b-radio-button size="small" name="percent"
-              v-model="percent" native-value="percent" >
-              Percent
-            </b-radio-button>
-            <b-radio-button size="small" name="percent"
-              v-model="percent" native-value="accumulative" >
-              Accumulative
+            <b-radio-button size="small" name="display"
+              v-model="display" native-value="percent" >
+              percent
             </b-radio-button>
           </b-field>
 
@@ -242,7 +245,12 @@ if (route.query.dates) {
 }
 
 const others = ref(route.query.others === null);
-const percent = ref(route.query.percent === null ? 'percent' : route.query.percent || 'absolute');
+const display = ref(
+  route.query.percent === null ? 'percent' :
+  route.query.accu === null ? 'accumulative' :
+  'absolute'
+);
+
 
 const updateUrl = () => {
   router.push({
@@ -258,7 +266,8 @@ const updateUrl = () => {
       chart: chart.value,
       dates: dates.value.map(d => d.toISOString().split("T")[0]).join(','),
       others: others.value ? null : undefined,
-      percent: percent.value === "percent" ? null : percent.value === "absolute" ? undefined : percent.value,
+      percent: display.value === "percent" ? null : undefined,
+      accu: display.value === "accumulative" ? null : undefined,
     },
   });
 }
@@ -273,8 +282,15 @@ watch([
   chart,
   dates,
   others,
-  percent,
+  display,
 ], updateUrl);
+
+// Avoid unsupported combinations:
+watch(metric, () => {
+  if (metric.value === "contributor" && display.value === "accumulative") {
+    display.value = "absolute";
+  }
+});
 
 </script>
 


### PR DESCRIPTION
Adds a third visualization mode "Accumulative" (alongside existing "Absolute" and "Percent" options) in the organizations page.

This shows running totals over time, helping users analyze contribution growth patterns and cumulative impact.