### PR TITLE
Track Open Screen repository

### DIFF
--- a/repositories.json5
+++ b/repositories.json5
@@ -252,4 +252,14 @@
     reviewers: false,
     treemap: false,
   },
+
+  {
+    name: "Open Screen",
+    dirname: "openscreen",
+    color: "#1abc9c",
+    owner: "chromium",
+    repository: "openscreen",
+    reviewers: true,
+    treemap: false,
+  },
 ]


### PR DESCRIPTION
Adds the Open Screen library ([`chromium/openscreen`](https://chromium.googlesource.com/openscreen/)) to the tracked repositories.

Open Screen is part of the Chromium ecosystem (alongside Dawn, ANGLE, Skia, PDFium, etc.) and is developed on Gerrit using `Reviewed-by:` trailers, so `reviewers` parsing is enabled. The default branch is auto-detected, and `treemap` is left disabled.

```json5
{
  name: "Open Screen",
  dirname: "openscreen",
  color: "#1abc9c",
  owner: "chromium",
  repository: "openscreen",
  reviewers: true,
  treemap: false,
}
```